### PR TITLE
Adding support of key name / key pair during creation of the instance

### DIFF
--- a/.forms.yml
+++ b/.forms.yml
@@ -115,6 +115,12 @@ aws-ec2:
         widget: text_area
         type: string
         default: ""
+      - name: "Key name"
+        description: "Key name of the Key Pair to use for the instance."
+        key: module.vm.key_name
+        widget: simple_text
+        type: string
+        default: ""
       - name: "Vm type"
         description: "Type of instance to use for the instance."
         key: module.vm.instance_type

--- a/AWS_README.md
+++ b/AWS_README.md
@@ -48,6 +48,7 @@ Name|Description|Type|Default|Required|
 |---|---|:---:|:---:|:---:|
 |`instance_type`|The instance type to use for the instance. "|`string`|``|`True`|
 |`file_content`|The content of the file to use if cloud init is used.|`string`|``|`False`|
+|`key_name`|Key name of the Key Pair to use for the instance.|`string`|``|`False`|
 |`instance_extra_tags`|A map of tags to assign to the resource.|`-`|``|`False`|
 
 **Network Configurations**

--- a/terraform/aws/module-ec2/ec2.tf
+++ b/terraform/aws/module-ec2/ec2.tf
@@ -67,6 +67,9 @@ resource "aws_instance" "vm" {
   // cloud init script - if enabled 
   user_data_base64 = base64encode(data.template_file.user_data.rendered)
 
+  // keypair name - if enabled
+  key_name = var.key_name
+
   //network
   vpc_security_group_ids      = [aws_security_group.ec2.id]
   subnet_id                   = var.subnet_id

--- a/terraform/aws/module-ec2/variables.tf
+++ b/terraform/aws/module-ec2/variables.tf
@@ -119,6 +119,11 @@ variable "instance_extra_tags" {
   default     = {}
 }
 
+variable "key_name" {
+  description = "Key name of the Key Pair to use for the instance."
+  default     = ""
+}
+
 //EC2- Network
 variable "subnet_id" {
   description = "VPC Subnet ID to launch in."

--- a/terraform/aws/vm.tf.sample
+++ b/terraform/aws/vm.tf.sample
@@ -92,6 +92,10 @@ module "vm" {
   #+ A map of tags to assign to the resource.
   instance_extra_tags =  {}
 
+  #. key_name (optional, string):
+  #+ Key name of the Key Pair to use for the instance
+  key_name =  ""
+
   ## EC2-Network
 
   #. subnet_id (required, string):


### PR DESCRIPTION
## Description

Added support for [`key_name`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#key_name) during an AWS instance deployment. Thus, adding an existing key pair to connect to the deployed machine via SSH is possible. By default, there is no key pair attached